### PR TITLE
Added “Remove Fullscreen Button” Option

### DIFF
--- a/Settings.x
+++ b/Settings.x
@@ -188,6 +188,7 @@ static YTSettingsSectionItem *createSwitchItem(NSString *title, NSString *key, B
                 createSwitchItem(@"NoDarkBg", @"noDarkBg", &kNoDarkBg, selfObject),
                 createSwitchItem(@"NoEndScreenCards", @"endScreenCards", &kEndScreenCards, selfObject),
                 createSwitchItem(@"NoFullscreenActions", @"noFullscreenActions", &kNoFullscreenActions, selfObject),
+                createSwitchItem(@"NoFullscreenButton", @"noFullscreenButton", &kNoFullscreenButton, selfObject),
                 createSwitchItem(@"PersistentProgressBar", @"persistentProgressBar", &kPersistentProgressBar, selfObject),
                 createSwitchItem(@"NoRelatedVids", @"noRelatedVids", &kNoRelatedVids, selfObject),
                 createSwitchItem(@"NoPromotionCards", @"noPromotionCards", &kNoPromotionCards, selfObject),

--- a/YTLite.h
+++ b/YTLite.h
@@ -40,6 +40,7 @@ BOOL kReplacePrevNext;
 BOOL kNoDarkBg;
 BOOL kEndScreenCards;
 BOOL kNoFullscreenActions;
+BOOL kNoFullscreenButton;
 BOOL kPersistentProgressBar;
 BOOL kNoRelatedVids;
 BOOL kNoPromotionCards;

--- a/YTLite.x
+++ b/YTLite.x
@@ -229,6 +229,22 @@ static UIImage *YTImageNamed(NSString *imageName) {
 - (void)setEnabled:(BOOL)arg1 { kNoFullscreenActions ? %orig(NO) : %orig; }
 %end
 
+// Hide Fullscreen Button
+%hook YTInlinePlayerBarContainerView
+- (void)layoutSubviews {
+    %orig;
+    if (kNoFullscreenButton) {
+        if (self.exitFullscreenButton) {
+            [self.exitFullscreenButton removeFromSuperview];
+        }
+        if (self.enterFullscreenButton) {
+            [self.enterFullscreenButton removeFromSuperview];
+        }
+        self.fullscreenButtonDisabled = YES;
+    }
+}
+%end
+
 // Dont Show Related Videos on Finish
 %hook YTFullscreenEngagementOverlayController
 - (void)setRelatedVideosVisible:(BOOL)arg1 { kNoRelatedVids ? %orig(NO) : %orig; }
@@ -1243,6 +1259,7 @@ static void reloadPrefs() {
     kNoDarkBg = [prefs[@"noDarkBg"] boolValue] ?: NO;
     kEndScreenCards = [prefs[@"endScreenCards"] boolValue] ?: NO;
     kNoFullscreenActions = [prefs[@"noFullscreenActions"] boolValue] ?: NO;
+    kNoFullscreenButton = [prefs[@"noFullscreenButton"] boolValue] ?: NO;
     kPersistentProgressBar = [prefs[@"persistentProgressBar"] boolValue] ?: NO;
     kNoRelatedVids = [prefs[@"noRelatedVids"] boolValue] ?: NO;
     kNoPromotionCards = [prefs[@"noPromotionCards"] boolValue] ?: NO;
@@ -1340,6 +1357,7 @@ static void reloadPrefs() {
         @"noDarkBg" : @(kNoDarkBg),
         @"endScreenCards" : @(kEndScreenCards),
         @"noFullscreenActions" : @(kNoFullscreenActions),
+        @"noFullscreenButton" : @(kNoFullscreenButton),
         @"persistentProgressBar" : @(kPersistentProgressBar),
         @"noRelatedVids" : @(kNoRelatedVids),
         @"noPromotionCards" : @(kNoPromotionCards),

--- a/YTLite.x
+++ b/YTLite.x
@@ -240,7 +240,7 @@ static UIImage *YTImageNamed(NSString *imageName) {
         if (self.enterFullscreenButton) {
             [self.enterFullscreenButton removeFromSuperview];
         }
-        self.fullscreenButtonDisabled = YES;
+//      self.fullscreenButtonDisabled = YES;
     }
 }
 %end

--- a/YTLite.x
+++ b/YTLite.x
@@ -236,9 +236,11 @@ static UIImage *YTImageNamed(NSString *imageName) {
     if (kNoFullscreenButton) {
         if (self.exitFullscreenButton) {
             [self.exitFullscreenButton removeFromSuperview];
+            self.exitFullscreenButton.frame = CGRectZero;
         }
         if (self.enterFullscreenButton) {
             [self.enterFullscreenButton removeFromSuperview];
+            self.enterFullscreenButton.frame = CGRectZero;
         }
 //      self.fullscreenButtonDisabled = YES;
     }

--- a/layout/Library/Application Support/YTLite.bundle/en.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YTLite.bundle/en.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "NoEndScreenCardsDesc" = "Hides End screens (thumbnails) at the end of videos.";
 "NoFullscreenActions" = "Disable fullscreen actions";
 "NoFullscreenActionsDesc" = "Disables actions panel in fullscreen mode.";
+"NoFullscreenButton" = "Remove fullscreen button";
+"NoFullscreenButtonDesc" = "Removes the fullscreen button in the player.";
 "PersistentProgressBar" = "Persistent progress bar";
 "PersistentProgressBarDesc" = "Always shows progress bar in the player.";
 "NoRelatedVids" = "No related videos in overlay";

--- a/layout/Library/Application Support/YTLite.bundle/es.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YTLite.bundle/es.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "NoEndScreenCardsDesc" = "Oculta las tarjetas emergentes de fin de pantalla (miniaturas) al final de los vídeos.";
 "NoFullscreenActions" = "Desactivar acciones en pantalla completa";
 "NoFullscreenActionsDesc" = "Desactiva el panel de acciones en el modo de pantalla completa.";
+"NoFullscreenButton" = "Remove fullscreen button";
+"NoFullscreenButtonDesc" = "Removes the fullscreen button in the player.";
 "PersistentProgressBar" = "Barra de progreso persistente";
 "PersistentProgressBarDesc" = "Muestra siempre la barra de progreso en el reproductor.";
 "NoRelatedVids" = "Sin vídeos relacionados en la superposición";

--- a/layout/Library/Application Support/YTLite.bundle/fr.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YTLite.bundle/fr.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "NoEndScreenCardsDesc" = "Masque les cartes de fin d'écran (vignettes) à la fin des vidéos.";
 "NoFullscreenActions" = "Désactiver les actions en plein écran";
 "NoFullscreenActionsDesc" = "Désactive le panneau d'actions en mode plein écran.";
+"NoFullscreenButton" = "Remove fullscreen button";
+"NoFullscreenButtonDesc" = "Removes the fullscreen button in the player.";
 "PersistentProgressBar" = "Barre de progression persistante";
 "PersistentProgressBarDesc" = " Affiche toujours la barre de progression dans le lecteur ";
 "NoRelatedVids" = "Pas de vidéos associées dans l'overlay";

--- a/layout/Library/Application Support/YTLite.bundle/ja.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YTLite.bundle/ja.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "NoEndScreenCardsDesc" = "動画の終わりに表示されるエンドスクリーン(サムネイル)を非表示にします";
 "NoFullscreenActions" = "フルスクリーンアクションを無効化";
 "NoFullscreenActionsDesc" = "フルスクリーンモードでのアクションパネルを無効にします";
+"NoFullscreenButton" = "Remove fullscreen button";
+"NoFullscreenButtonDesc" = "Removes the fullscreen button in the player.";
 "PersistentProgressBar" = "Persistent progress bar";
 "PersistentProgressBarDesc" = "Always shows progress bar in the player.";
 "NoRelatedVids" = "オーバーレイの関連動画を非表示";

--- a/layout/Library/Application Support/YTLite.bundle/ru.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YTLite.bundle/ru.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "NoEndScreenCardsDesc" = "Скрывает эскизы, отображаемые по окончанию видеоролика.";
 "NoFullscreenActions" = "Отключить панель действий";
 "NoFullscreenActionsDesc" = "Отключает панель действий, отображающуюся под прогресс-баром плеера.";
+"NoFullscreenButton" = "Remove fullscreen button";
+"NoFullscreenButtonDesc" = "Removes the fullscreen button in the player.";
 "PersistentProgressBar" = "Всегда отображать прогресс-бар";
 "PersistentProgressBarDesc" = "Всегда отображает прогресс-бар внутри плеера.";
 "NoRelatedVids" = "Скрыть рекомендации в оверлее";

--- a/layout/Library/Application Support/YTLite.bundle/vi.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YTLite.bundle/vi.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "NoEndScreenCardsDesc" = "Ẩn thumbnail của các video đề xuất, xuất hiện ở cuối video.";
 "NoFullscreenActions" = "Vô hiệu hóa các hành động toàn màn hình";
 "NoFullscreenActionsDesc" = "Vô hiệu hóa bảng hành động ở chế độ toàn màn hình.";
+"NoFullscreenButton" = "Remove fullscreen button";
+"NoFullscreenButtonDesc" = "Removes the fullscreen button in the player.";
 "PersistentProgressBar" = "Thanh tiến trình liên tục";
 "PersistentProgressBarDesc" = "Luôn hiển thị thanh tiến trình trong trình phát.";
 "NoRelatedVids" = "Không có video liên quan trong lớp phủ";

--- a/layout/Library/Application Support/YTLite.bundle/zh-Hans.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YTLite.bundle/zh-Hans.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "NoEndScreenCardsDesc" = "隐藏视频结尾处的片尾屏幕（缩略图）。";
 "NoFullscreenActions" = "禁用全屏操作";
 "NoFullscreenActionsDesc" = "在全屏模式下禁用操作面板。";
+"NoFullscreenButton" = "Remove fullscreen button";
+"NoFullscreenButtonDesc" = "Removes the fullscreen button in the player.";
 "PersistentProgressBar" = "持续进度条";
 "PersistentProgressBarDesc" = "始终在播放器中显示进度条。";
 "NoRelatedVids" = "没有相关视频";

--- a/layout/Library/Application Support/YTLite.bundle/zh-Hant.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YTLite.bundle/zh-Hant.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "NoEndScreenCardsDesc" = "隱藏當影片結束時的懸停影片（縮圖）";
 "NoFullscreenActions" = "停用全螢幕操作";
 "NoFullscreenActionsDesc" = "在全螢幕模式下停用操作面板";
+"NoFullscreenButton" = "Remove fullscreen button";
+"NoFullscreenButtonDesc" = "Removes the fullscreen button in the player.";
 "PersistentProgressBar" = "固定進度條";
 "PersistentProgressBarDesc" = "總是在播放器中顯示進度條";
 "NoRelatedVids" = "隱藏相關影片";


### PR DESCRIPTION
Another new option that may be an helpful addition to YTLite.
this one allows you to completely hide the Fullscreen Button that is shown on the **bottom right** of the video player.

And I do also allow you to modify/edit this pull request if you see anything that isn’t needed.


~There might be a possible compiling error if line isn’t present in the YouTubeheaders.
`@property (nonatomic, assign, readwrite) BOOL fullscreenButtonDisabled;` - https://github.com/arichornlover/YouTubeHeader/commit/3d90fbbc491ac7d3f043322f7eb9bc4dcb474afc~ as of March 5th, I disabled the line for the YTLite tweak. You can skip this.

### About the other Pull Request ✅
I do think the other pull request is possible. https://github.com/dayanch96/YTLite/pull/33
PoomSmart recently added headers for stuff like the ability to hide the Buttons under the video player, etc. I’ll look into that.