### PR TITLE
migrate to cyan, fixed build with tweaks workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Set PATH environment variable
         run: echo "$(brew --prefix make)/libexec/gnubin" >> $GITHUB_PATH
 
-      - name: Install Pyzule
-        run: bash -c "$(curl https://raw.githubusercontent.com/asdfzxcvbn/pyzule/main/install-pyzule.sh)"
+      - name: Install cyan
+        run: pip install https://github.com/asdfzxcvbn/pyzule-rw/archive/main.zip
 
       - name: Download YouTube
         id: download_youtube
@@ -58,7 +58,7 @@ jobs:
           mv *.appex ${{ github.workspace }}
 
       - name: Inject tweak into IPA
-        run: pyzule -i ${{ github.workspace }}/youtube.ipa -o ${{ github.workspace }}/YouTubePlus_${{ inputs.tweak_version }}.ipa -f ${{ github.workspace }}/ytplus.deb ${{ github.workspace }}/OpenYoutubeSafariExtension.appex -w -u
+        run: cyan -i youtube.ipa -o YouTubePlus_${{ inputs.tweak_version }}.ipa -uwf ytplus.deb OpenYoutubeSafariExtension.appex
 
       - name: Upload to GitHub Releases
         uses: softprops/action-gh-release@v2.0.1

--- a/.github/workflows/ytp_tweaks.yml
+++ b/.github/workflows/ytp_tweaks.yml
@@ -34,7 +34,7 @@ jobs:
           submodules: recursive
 
       - name: Install Dependencies
-        run: brew install make
+        run: brew install make ldid
 
       - name: Set PATH environment variable
         run: echo "$(brew --prefix make)/libexec/gnubin" >> $GITHUB_PATH

--- a/.github/workflows/ytp_tweaks.yml
+++ b/.github/workflows/ytp_tweaks.yml
@@ -69,8 +69,8 @@ jobs:
         env:
           THEOS: ${{ github.workspace }}/theos
 
-      - name: Install Pyzule
-        run: bash -c "$(curl https://raw.githubusercontent.com/asdfzxcvbn/pyzule/main/install-pyzule.sh)"
+      - name: Install cyan
+        run: pip install https://github.com/asdfzxcvbn/pyzule-rw/archive/main.zip
 
       - name: Download YouTube
         id: download_youtube
@@ -144,7 +144,9 @@ jobs:
           THEOS: ${{ github.workspace }}/theos
 
       - name: Inject tweaks into IPA
-        run: pyzule -i ${{ github.workspace }}/youtube.ipa -o ${{ github.workspace }}/YouTubePlus_${{ inputs.tweak_version }}_Tweaks.ipa -w -u -f ${{ github.workspace }}/ytplus.deb ${{ github.workspace }}/OpenYoutubeSafariExtension.appex ${{ github.workspace }}/youpip.deb ${{ github.workspace }}/ytuhd.deb ${{ github.workspace }}/ryd.deb
+        run: |
+          cyan -i youtube.ipa -o YouTubePlus_${{ inputs.tweak_version }}_Tweaks.ipa \
+            -uwf ytplus.deb OpenYoutubeSafariExtension.appex youpip.deb ytuhd.deb ryd.deb
 
       - name: Upload to GitHub Releases
         uses: softprops/action-gh-release@v2.0.1


### PR DESCRIPTION
> pyzule has been deprecated in favor of cyan, which fixes a specific installation bug for jailbroken users, as well as QoL changes and code improvements

there was also strangely a build bug in the "build with tweaks" workflow, fixed by installing ldid