### PR TITLE
fix: misleading indent causing build error

### DIFF
--- a/Sideloading.x
+++ b/Sideloading.x
@@ -21,8 +21,8 @@ static NSString *accessGroupID() {
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
     if (status == errSecItemNotFound)
         status = SecItemAdd((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
-        if (status != errSecSuccess)
-            return nil;
+    if (status != errSecSuccess)
+        return nil;
     NSString *accessGroup = [(__bridge NSDictionary *)result objectForKey:(__bridge NSString *)kSecAttrAccessGroup];
 
     return accessGroup;


### PR DESCRIPTION
Hi, I am not sure if this is intended to be like this, but when I try to compile the deb for this it errors on my environment.

==> Compiling Sideloading.x (arm64)…
Sideloading.x:24:9: error: misleading indent
        if (status != errSecSuccess)
        ^
Sideloading.x:22:5: note: previous statement
    if (status == errSecItemNotFound)
    ^
1 error generated.

The changes I did seemed to fix the problem, however I know nothing about iOS tweak development with Theos so I don't know if this was intended to be like this or not. I am using Linux to build and maybe on MacOS it works with the indent? Anyways, it's at your own discretion, simply trying to help :)