### PR TITLE
Update main.yml iOS SDK source & version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           git clone --quiet -n --depth=1 --filter=tree:0 https://github.com/xybp888/ios-sdks/ sdks
           cd sdks
-          git sparse-checkout set --no-cone iPhoneOS16.5.sdk
+          git sparse-checkout set --no-cone iPhoneOS26.2.sdk
           git checkout
           mv *.sdk $THEOS/sdks
         env:


### PR DESCRIPTION
The commits are pretty self-explanitory:
- SDK source changed from theos/sdks to xybp888/ios-sdks because it's actively maintained and contains the latest SDK(s)
- Updated the used iOS SDK to 26.2—latest as of today