### PR TITLE
Update build script and dependencies to remove Node24 warnings

### DIFF
--- a/.github/workflows/_build_tweaks.yml
+++ b/.github/workflows/_build_tweaks.yml
@@ -62,7 +62,7 @@ jobs:
         id: theos
         uses: actions/cache@v5
         env:
-          cache-name: theos_cache_13c2237
+          cache-name: theos_cache_9bc7340
         with:
           path: theos/
           key: ${{ env.cache-name }}
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: theos/theos
-          ref: 13c22376b5d83ff759c1993de0a861e673aa522b
+          ref: 9bc73406cf80b711ef4d02c15ff1dedc4478a275
           path: theos
           submodules: recursive
 
@@ -149,7 +149,7 @@ jobs:
         run: git clone --quiet --depth=1 https://github.com/PoomSmart/YouQuality.git
 
       - name: Clone YTVideoOverlay
-        if: ${{ inputs.enable_yq || inputs.enable_youpip }}
+        if: ${{ inputs.enable_yq || inputs.enable_youpip || inputs.enable_ytuhd }}
         run: git clone --quiet --depth=1 https://github.com/PoomSmart/YTVideoOverlay.git
 
       - name: Clone DontEatMyContent
@@ -165,7 +165,7 @@ jobs:
       - name: Build YTUHD
         if: ${{ inputs.enable_ytuhd }}
         run: |
-          cd YTUHD && make clean package DEBUG=0 FINALPACKAGE=1 ARCHS=arm64
+          cd YTUHD && make clean package DEBUG=0 FINALPACKAGE=1
           mv packages/*.deb ../ytuhd.deb
 
       - name: Build Return-YouTube-Dislikes
@@ -193,7 +193,7 @@ jobs:
           mv packages/*.deb ../yq.deb
 
       - name: Build YTVideoOverlay
-        if: ${{ inputs.enable_yq || inputs.enable_youpip }}
+        if: ${{ inputs.enable_yq || inputs.enable_youpip || inputs.enable_ytuhd }}
         run: |
           cd YTVideoOverlay && make clean package DEBUG=0 FINALPACKAGE=1
           mv packages/*.deb ../ytvo.deb
@@ -213,7 +213,7 @@ jobs:
           mv *.appex ..
 
       - name: Upload built debs as artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: built-debs
           path: |

--- a/.github/workflows/cyan_ts.yml
+++ b/.github/workflows/cyan_ts.yml
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Download built debs
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: built-debs
           path: ${{ github.workspace }}
@@ -150,7 +150,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Upload to GitHub Releases
-        uses: softprops/action-gh-release@v2.5.0
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ytp-${{ github.run_number }}
           name: YouTubePlus v${{ github.event.inputs.tweak_version }}_cyan_trollfools (${{ github.run_number }})

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Download built debs
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: built-debs
           path: ${{ github.workspace }}
@@ -116,7 +116,6 @@ jobs:
       - name: Install cyan
         run: pipx install --force https://github.com/asdfzxcvbn/pyzule-rw/archive/main.zip
 
-
       - name: Inject tweaks into IPA
         run: |
           tweaks="ytplus.deb OpenYoutubeSafariExtension.appex"
@@ -126,7 +125,7 @@ jobs:
           cyan -i youtube.ipa -o YouTubePlus_${{ github.event.inputs.tweak_version }}.ipa -uwef $tweaks -n "${{ github.event.inputs.display_name }}" -b ${{ github.event.inputs.bundle_id }}
 
       - name: Upload to GitHub Releases
-        uses: softprops/action-gh-release@v2.5.0
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ytp-${{ github.run_number }}
           name: YouTubePlus v${{ github.event.inputs.tweak_version }} (${{ github.run_number }})

--- a/.github/workflows/ytp_beta.yml
+++ b/.github/workflows/ytp_beta.yml
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Download built debs
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: built-debs
           path: ${{ github.workspace }}
@@ -116,7 +116,6 @@ jobs:
       - name: Install cyan
         run: pipx install --force https://github.com/asdfzxcvbn/pyzule-rw/archive/main.zip
 
-
       - name: Inject tweaks into IPA
         run: |
           tweaks="ytplus.deb OpenYoutubeSafariExtension.appex"
@@ -126,7 +125,7 @@ jobs:
           cyan -i youtube.ipa -o YouTubePlus_Beta.ipa -uwef $tweaks -n "${{ github.event.inputs.display_name }}" -b ${{ github.event.inputs.bundle_id }}
 
       - name: Upload to GitHub Releases
-        uses: softprops/action-gh-release@v2.5.0
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ytp-beta-${{ github.run_number }}
           name: YouTubePlus Beta (${{ github.run_number }})


### PR DESCRIPTION
## What’s changed
- Update theos commit to the latest.
- Bump every dependencies version to the latest.
- Remove `ARCH=arm64` in YTUHD build script since I removed arm64e from its `Makefile`.
- Make the build script clone and build YTVideoOverlay if YTUHD needs to be integrate. (It’s now require to have YTVideoOverlay injected for YTUHD.)