### PR TITLE
Add optional localization update step to workflows

### DIFF
--- a/.github/workflows/_build_tweaks.yml
+++ b/.github/workflows/_build_tweaks.yml
@@ -33,6 +33,11 @@ on:
         required: true
         default: false
 
+      enable_localization:
+        type: boolean
+        required: true
+        default: false
+
       tweak_version:
         type: string
         required: false
@@ -49,6 +54,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - uses: actions/checkout@v6
+        if: ${{ inputs.enable_localization }}
+
       - name: Install Dependencies
         run: brew install make ldid dpkg
 
@@ -211,6 +219,20 @@ jobs:
           git sparse-checkout set --no-cone OpenYoutubeSafariExtension.appex
           git checkout
           mv *.appex ..
+
+      - name: Update localization
+        if: ${{ inputs.enable_localization }}
+        run: |
+          mkdir debdir
+          dpkg-deb -R ytplus.deb debdir
+          rm ytplus.deb
+          find "layout/Library/Application Support/YTLite.bundle" \
+            -mindepth 1 -maxdepth 1 -type d -name "*.lproj" -not -name "en.lproj" \
+            -exec cp -R "{}" "debdir/Library/Application Support/YTLite.bundle/" \;
+          cd debdir/
+          find . -type f -not -path "./DEBIAN/*" -exec md5sum {} + | sort -k 2 | sed 's/\.\/\(.*\)/\1/' > DEBIAN/md5sums
+          cd ../
+          dpkg-deb --root-owner-group -b debdir ytplus.deb
 
       - name: Upload built debs as artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,12 @@ on:
         required: true
         default: false
 
+      enable_localization:
+        description: "Update localization files from repo"
+        type: boolean
+        required: true
+        default: false
+
       ipa_url:
         description: "URL to the decrypted IPA file"
         default: ""
@@ -83,6 +89,7 @@ jobs:
       enable_ryd: ${{ inputs.enable_ryd }}
       enable_ytabc: ${{ inputs.enable_ytabc }}
       enable_demc: ${{ inputs.enable_demc }}
+      enable_localization: ${{ inputs.enable_localization }}
       tweak_version: ${{ inputs.tweak_version }}
 
   package:
@@ -102,7 +109,7 @@ jobs:
       - name: Hide sensitive inputs
         uses: levibostian/action-hide-sensitive-inputs@v1
         with:
-          exclude_inputs: bundle_id,display_name,enable_demc,enable_ryd,enable_ytabc,enable_youpip,enable_yq,enable_ytuhd,info_note,tweak_version
+          exclude_inputs: bundle_id,display_name,enable_demc,enable_ryd,enable_ytabc,enable_youpip,enable_yq,enable_ytuhd,enable_localization,info_note,tweak_version
 
       - name: Download and validate IPA
         run: |

--- a/.github/workflows/ytp_beta.yml
+++ b/.github/workflows/ytp_beta.yml
@@ -39,6 +39,12 @@ on:
         required: true
         default: false
 
+      enable_localization:
+        description: "Update localization files from repo"
+        type: boolean
+        required: true
+        default: false
+
       ipa_url:
         description: "URL to the decrypted IPA file"
         default: ""
@@ -83,6 +89,7 @@ jobs:
       enable_ryd: ${{ inputs.enable_ryd }}
       enable_ytabc: ${{ inputs.enable_ytabc }}
       enable_demc: ${{ inputs.enable_demc }}
+      enable_localization: ${{ inputs.enable_localization }}
       tweak_url: ${{ inputs.tweak_url }}
 
   package:
@@ -102,7 +109,7 @@ jobs:
       - name: Hide sensitive inputs
         uses: levibostian/action-hide-sensitive-inputs@v1
         with:
-          exclude_inputs: bundle_id,display_name,enable_demc,enable_ryd,enable_ytabc,enable_youpip,enable_yq,enable_ytuhd,info_note
+          exclude_inputs: bundle_id,display_name,enable_demc,enable_ryd,enable_ytabc,enable_youpip,enable_yq,enable_ytuhd,enable_localization,info_note
 
       - name: Download and validate IPA
         run: |


### PR DESCRIPTION
Add an optional workflow step that updates the YTPlus localization files from the current Localizable files in the repository during plugin/IPA build.

This is my proposal to ensure that the .ipa generated by the workflow always includes up-to-date translations based on the repository.