### PR TITLE
Show configured skip intervals in Control Center

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TARGET := iphone:clang:16.5:13.0
 include $(THEOS)/makefiles/common.mk
 
 TWEAK_NAME = YTLite
-$(TWEAK_NAME)_FRAMEWORKS = UIKit Foundation SystemConfiguration
+$(TWEAK_NAME)_FRAMEWORKS = UIKit Foundation MediaPlayer SystemConfiguration
 $(TWEAK_NAME)_CFLAGS = -fobjc-arc -DTWEAK_VERSION=$(PACKAGE_VERSION)
 $(TWEAK_NAME)_FILES = $(wildcard *.x Utils/*.m)
 

--- a/RemoteControls.x
+++ b/RemoteControls.x
@@ -1,0 +1,51 @@
+#import "YTLite.h"
+#import <MediaPlayer/MediaPlayer.h>
+
+static BOOL ytlDidSetSkipBackwardTarget = NO;
+static BOOL ytlDidSetSkipForwardTarget = NO;
+
+static NSInteger YTLRemoteControlInterval(NSString *key) {
+    NSInteger interval = [[YTLUserDefaults standardUserDefaults] integerForKey:key];
+    return interval > 0 ? interval : 10;
+}
+
+static void YTLConfigureRemoteControlCommands() {
+    MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
+    BOOL skipBackwardEnabled = ytlBool(@"rcSkipBackward");
+    BOOL skipForwardEnabled = ytlBool(@"rcSkipForward");
+
+    commandCenter.skipBackwardCommand.preferredIntervals = @[@(YTLRemoteControlInterval(@"rcSkipBackwardSec"))];
+    commandCenter.skipForwardCommand.preferredIntervals = @[@(YTLRemoteControlInterval(@"rcSkipForwardSec"))];
+
+    commandCenter.skipBackwardCommand.enabled = skipBackwardEnabled;
+    commandCenter.skipForwardCommand.enabled = skipForwardEnabled;
+    commandCenter.previousTrackCommand.enabled = !skipBackwardEnabled;
+    commandCenter.nextTrackCommand.enabled = !skipForwardEnabled;
+}
+
+%hook MPRemoteCommand
+- (void)addTarget:(id)target action:(SEL)action {
+    %orig;
+
+    MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
+
+    if (self == commandCenter.previousTrackCommand && !ytlDidSetSkipBackwardTarget) {
+        [commandCenter.skipBackwardCommand addTarget:target action:action];
+        ytlDidSetSkipBackwardTarget = YES;
+    }
+
+    if (self == commandCenter.nextTrackCommand && !ytlDidSetSkipForwardTarget) {
+        [commandCenter.skipForwardCommand addTarget:target action:action];
+        ytlDidSetSkipForwardTarget = YES;
+    }
+
+    YTLConfigureRemoteControlCommands();
+}
+%end
+
+%hook MPNowPlayingInfoCenter
+- (void)setNowPlayingInfo:(NSDictionary<NSString *, id> *)nowPlayingInfo {
+    %orig;
+    YTLConfigureRemoteControlCommands();
+}
+%end

--- a/Settings.x
+++ b/Settings.x
@@ -6,6 +6,26 @@
 
 static const NSInteger YTLiteSection = 789;
 
+static NSArray<NSNumber *> *YTLControlCenterIntervals() {
+    return @[@5, @10, @15, @30, @45, @60];
+}
+
+static NSInteger YTLControlCenterInterval(NSString *key) {
+    NSInteger interval = [[YTLUserDefaults standardUserDefaults] integerForKey:key];
+    return interval > 0 ? interval : 10;
+}
+
+static NSUInteger YTLSelectedIntervalIndex(NSString *key) {
+    NSArray<NSNumber *> *intervals = YTLControlCenterIntervals();
+    NSNumber *selectedValue = @(YTLControlCenterInterval(key));
+    NSUInteger index = [intervals indexOfObject:selectedValue];
+    return index == NSNotFound ? 1 : index;
+}
+
+static NSString *YTLIntervalLabel(NSString *key) {
+    return [NSString stringWithFormat:@"%ld s", (long)YTLControlCenterInterval(key)];
+}
+
 static NSString *GetCacheSize() {
     NSString *cachePath = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
     NSArray *filesArray = [[NSFileManager defaultManager] subpathsOfDirectoryAtPath:cachePath error:nil];
@@ -106,6 +126,37 @@ static NSString *GetCacheSize() {
     detailTextBlock:nil
     selectBlock:^BOOL (YTSettingsCell *cell, NSUInteger arg1) {
         return [%c(YTUIUtils) openURL:[NSURL URLWithString:link]];
+    }];
+}
+
+%new
+- (YTSettingsSectionItem *)intervalItemWithTitle:(NSString *)title key:(NSString *)key {
+    Class YTSettingsSectionItemClass = %c(YTSettingsSectionItem);
+    YTSettingsViewController *settingsViewController = [self valueForKey:@"_settingsViewControllerDelegate"];
+
+    return [YTSettingsSectionItemClass itemWithTitle:LOC(title)
+    accessibilityIdentifier:@"YTLiteSectionItem"
+    detailTextBlock:^NSString *() {
+        return YTLIntervalLabel(key);
+    }
+    selectBlock:^BOOL (YTSettingsCell *cell, NSUInteger arg1) {
+        NSMutableArray <YTSettingsSectionItem *> *rows = [NSMutableArray array];
+        NSArray<NSNumber *> *intervals = YTLControlCenterIntervals();
+
+        for (NSNumber *interval in intervals) {
+            NSString *label = [NSString stringWithFormat:@"%@ s", interval];
+            YTSettingsSectionItem *item = [YTSettingsSectionItemClass checkmarkItemWithTitle:label titleDescription:nil selectBlock:^BOOL (YTSettingsCell *cell, NSUInteger arg1) {
+                [settingsViewController reloadData];
+                ytlSetInt(interval.integerValue, key);
+                return YES;
+            }];
+
+            [rows addObject:item];
+        }
+
+        YTSettingsPickerViewController *picker = [[%c(YTSettingsPickerViewController) alloc] initWithNavTitle:LOC(title) pickerSectionTitle:nil rows:rows selectedItemIndex:YTLSelectedIntervalIndex(key) parentResponder:[self parentResponder]];
+        [settingsViewController pushViewController:picker];
+        return YES;
     }];
 }
 
@@ -231,6 +282,26 @@ static NSString *GetCacheSize() {
         }];
 
         [sectionItems addObject:player];
+
+        YTSettingsSectionItem *controlCenter = [YTSettingsSectionItemClass itemWithTitle:LOC(@"Player.ControlCenter")
+        accessibilityIdentifier:@"YTLiteSectionItem"
+        detailTextBlock:^NSString *() {
+            return @"‣";
+        }
+        selectBlock:^BOOL (YTSettingsCell *cell, NSUInteger arg1) {
+            NSArray <YTSettingsSectionItem *> *rows = @[
+                [self switchWithTitle:@"RcSkipBackward" key:@"rcSkipBackward"],
+                [self intervalItemWithTitle:@"RcSkipBackward" key:@"rcSkipBackwardSec"],
+                [self switchWithTitle:@"RcSkipForward" key:@"rcSkipForward"],
+                [self intervalItemWithTitle:@"RcSkipForward" key:@"rcSkipForwardSec"]
+            ];
+
+            YTSettingsPickerViewController *picker = [[%c(YTSettingsPickerViewController) alloc] initWithNavTitle:LOC(@"Player.ControlCenter") pickerSectionTitle:nil rows:rows selectedItemIndex:NSNotFound parentResponder:[self parentResponder]];
+            [settingsViewController pushViewController:picker];
+            return YES;
+        }];
+
+        [sectionItems addObject:controlCenter];
 
         YTSettingsSectionItem *shorts = [YTSettingsSectionItemClass itemWithTitle:LOC(@"Shorts")
         accessibilityIdentifier:@"YTLiteSectionItem"

--- a/Utils/YTLUserDefaults.m
+++ b/Utils/YTLUserDefaults.m
@@ -29,7 +29,9 @@ static NSString *const kDefaultsSuiteName = @"com.dvntm.ytlite";
         @"autoSpeedIndex": @3,
         @"wiFiQualityIndex": @0,
         @"cellQualityIndex": @0,
-        @"pivotIndex": @0
+        @"pivotIndex": @0,
+        @"rcSkipBackwardSec": @10,
+        @"rcSkipForwardSec": @10
     }];
 }
 

--- a/YTLite.h
+++ b/YTLite.h
@@ -29,6 +29,7 @@
 
 @interface YTSettingsSectionItemManager (Custom)
 - (YTSettingsSectionItem *)switchWithTitle:(NSString *)title key:(NSString *)key;
+- (YTSettingsSectionItem *)intervalItemWithTitle:(NSString *)title key:(NSString *)key;
 - (YTSettingsSectionItem *)linkWithTitle:(NSString *)title description:(NSString *)description link:(NSString *)link;
 - (UIImage *)resizedImageNamed:(NSString *)iconName;
 @end


### PR DESCRIPTION
This updates the Control Center skip commands so YTLite uses `skipBackwardCommand` / `skipForwardCommand`, mirrors the existing handlers onto those commands, and sets `preferredIntervals` from the configured skip durations.

It also exposes the missing Control Center settings in YTLite so the skip-forward and skip-backward toggles and intervals can be configured directly.

Validation:
- `git diff --check`

Closes dayanch96/YTLite#758
