### PR TITLE
Add YTAnotherMiniplayer tweak to workflows and fix README.md

### DIFF
--- a/.github/workflows/_build_tweaks.yml
+++ b/.github/workflows/_build_tweaks.yml
@@ -33,6 +33,11 @@ on:
         required: true
         default: false
 
+      enable_ytam:
+        type: boolean
+        required: true
+        default: false
+
       tweak_version:
         type: string
         required: false
@@ -58,7 +63,7 @@ jobs:
           echo "THEOS=${{ github.workspace }}/theos" >> $GITHUB_ENV
 
       - name: Cache Theos
-        if: ${{ inputs.enable_youpip || inputs.enable_ytuhd || inputs.enable_yq || inputs.enable_ryd || inputs.enable_ytabc || inputs.enable_demc }}
+        if: ${{ inputs.enable_youpip || inputs.enable_ytuhd || inputs.enable_yq || inputs.enable_ryd || inputs.enable_ytabc || inputs.enable_demc || inputs.enable_ytam }}
         id: theos
         uses: actions/cache@v5
         env:
@@ -69,7 +74,7 @@ jobs:
           restore-keys: ${{ env.cache-name }}
 
       - name: Setup Theos
-        if: ${{ (inputs.enable_youpip || inputs.enable_ytuhd || inputs.enable_yq || inputs.enable_ryd || inputs.enable_ytabc || inputs.enable_demc) && steps.theos.outputs.cache-hit != 'true' }}
+        if: ${{ (inputs.enable_youpip || inputs.enable_ytuhd || inputs.enable_yq || inputs.enable_ryd || inputs.enable_ytabc || inputs.enable_demc || inputs.enable_ytam) && steps.theos.outputs.cache-hit != 'true' }}
         uses: actions/checkout@v6
         with:
           repository: theos/theos
@@ -103,7 +108,7 @@ jobs:
           fi
 
       - name: Clone YouTubeHeader
-        if: ${{ inputs.enable_youpip || inputs.enable_ytuhd || inputs.enable_yq || inputs.enable_ryd || inputs.enable_ytabc || inputs.enable_demc }}
+        if: ${{ inputs.enable_youpip || inputs.enable_ytuhd || inputs.enable_yq || inputs.enable_ryd || inputs.enable_ytabc || inputs.enable_demc || inputs.enable_ytam }}
         run: |
           if [ -d "$THEOS/include/YouTubeHeader" ]; then
             cd $THEOS/include/YouTubeHeader && git pull
@@ -116,7 +121,7 @@ jobs:
           fi
 
       - name: Clone PSHeader
-        if: ${{ inputs.enable_youpip || inputs.enable_ytuhd || inputs.enable_yq || inputs.enable_ryd || inputs.enable_ytabc || inputs.enable_demc }}
+        if: ${{ inputs.enable_youpip || inputs.enable_ytuhd || inputs.enable_yq || inputs.enable_ryd || inputs.enable_ytabc || inputs.enable_demc || inputs.enable_ytam }}
         run: |
           if [ -d "$THEOS/include/PSHeader" ]; then
             cd $THEOS/include/PSHeader && git pull
@@ -151,6 +156,10 @@ jobs:
       - name: Clone YTVideoOverlay
         if: ${{ inputs.enable_yq || inputs.enable_youpip || inputs.enable_ytuhd }}
         run: git clone --quiet --depth=1 https://github.com/PoomSmart/YTVideoOverlay.git
+
+      - name: Clone YTAnotherMiniplayer
+        if: ${{ inputs.enable_ytam }}
+        run: git clone --quiet --depth=1 https://github.com/PoomSmart/YTAnotherMiniplayer.git
 
       - name: Clone DontEatMyContent
         if: ${{ inputs.enable_demc }}
@@ -197,6 +206,12 @@ jobs:
         run: |
           cd YTVideoOverlay && make clean package DEBUG=0 FINALPACKAGE=1
           mv packages/*.deb ../ytvo.deb
+
+      - name: Build YTAnotherMiniplayer
+        if: ${{ inputs.enable_ytam }}
+        run: |
+          cd YTAnotherMiniplayer && make clean package DEBUG=0 FINALPACKAGE=1
+          mv packages/*.deb ../ytam.deb
 
       - name: Build DontEatMyContent
         if: ${{ inputs.enable_demc }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,12 @@ on:
         required: true
         default: false
 
+      enable_ytam:
+        description: "Integrate YTAnotherMiniplayer"
+        type: boolean
+        required: true
+        default: false
+
       ipa_url:
         description: "URL to the decrypted IPA file"
         default: ""
@@ -83,6 +89,7 @@ jobs:
       enable_ryd: ${{ inputs.enable_ryd }}
       enable_ytabc: ${{ inputs.enable_ytabc }}
       enable_demc: ${{ inputs.enable_demc }}
+      enable_ytam: ${{ inputs.enable_ytam }}
       tweak_version: ${{ inputs.tweak_version }}
 
   package:
@@ -102,7 +109,7 @@ jobs:
       - name: Hide sensitive inputs
         uses: levibostian/action-hide-sensitive-inputs@v1
         with:
-          exclude_inputs: bundle_id,display_name,enable_demc,enable_ryd,enable_ytabc,enable_youpip,enable_yq,enable_ytuhd,info_note,tweak_version
+          exclude_inputs: bundle_id,display_name,enable_demc,enable_ryd,enable_ytabc,enable_youpip,enable_yq,enable_ytuhd,enable_ytam,info_note,tweak_version
 
       - name: Download and validate IPA
         run: |

--- a/.github/workflows/ytp_beta.yml
+++ b/.github/workflows/ytp_beta.yml
@@ -39,6 +39,12 @@ on:
         required: true
         default: false
 
+      enable_ytam:
+        description: "Integrate YTAnotherMiniplayer"
+        type: boolean
+        required: true
+        default: false
+
       ipa_url:
         description: "URL to the decrypted IPA file"
         default: ""
@@ -83,6 +89,7 @@ jobs:
       enable_ryd: ${{ inputs.enable_ryd }}
       enable_ytabc: ${{ inputs.enable_ytabc }}
       enable_demc: ${{ inputs.enable_demc }}
+      enable_ytam: ${{ inputs.enable_ytam }}
       tweak_url: ${{ inputs.tweak_url }}
 
   package:
@@ -102,7 +109,7 @@ jobs:
       - name: Hide sensitive inputs
         uses: levibostian/action-hide-sensitive-inputs@v1
         with:
-          exclude_inputs: bundle_id,display_name,enable_demc,enable_ryd,enable_ytabc,enable_youpip,enable_yq,enable_ytuhd,info_note
+          exclude_inputs: bundle_id,display_name,enable_demc,enable_ryd,enable_ytabc,enable_youpip,enable_yq,enable_ytuhd,enable_ytam,info_note
 
       - name: Download and validate IPA
         run: |

--- a/README.md
+++ b/README.md
@@ -147,3 +147,9 @@ Review by [@qbap](https://github.com/qbap) on ONE Jailbreak: https://onejailbrea
   <p><strong>DontEatMyContent preferences</strong> are available in the <strong>YouTube settings</strong>.</p>
   <p>Source code and additional information are available <a href="https://github.com/therealFoxster/DontEatMyContent">in therealFoxster's GitHub repository</a>.</p>
 </details>
+
+<details>
+  <summary>YTAnotherMiniplayer</summary>
+  <p>YTAnotherMiniplayer is a tweak developed by <a href="https://github.com/PoomSmart">PoomSmart</a> that change YouTube (20+) miniplayer to an alternative style.
+  <p>Source code and additional information are available <a href="https://github.com/PoomSmart/YTAnotherMiniplayer">in PoomSmart's GitHub repository</a>.</p>
+</details>

--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ Review by [@qbap](https://github.com/qbap) on ONE Jailbreak: https://onejailbrea
 
 <details>
   <summary>YTUHD</summary>
-  <p>YTUHD is a tweak developed by <a href="https://github.com/PoomSmart">PoomSmart</a> that unlocks 1440p (2K) and 2160p (4K) resolutions in the iOS YouTube app.</p>
+  <p>YTUHD is a tweak make by <a href="https://github.com/PoomSmart">PoomSmart</a> and modify by <a href="https://github.com/Tonwalter888">Tonwalter888</a> that unlocks 1440p (2K) and 2160p (4K) resolutions in the iOS YouTube app.</p>
   <p><strong>YTUHD preferences</strong> are available in the <strong>Video quality preferences</strong> section under <strong>YouTube settings</strong>.</p>
   <p>Source code and additional information are available <a href="https://github.com/PoomSmart/YTUHD">in PoomSmart's GitHub repository</a>.</p>
+  <p>Forked code and additional information are available <a href="https://github.com/Tonwalter888/YTUHD">in Tonwalter888's GitHub repository</a>.</p>
 </details>
 
 <details>


### PR DESCRIPTION
Add new (optional) tweak [YTAnotherMiniplayer](https://github.com/PoomSmart/YTAnotherMiniplayer) to workflows.

Uses an alternative YouTube miniplayer style.

<img width="381" height="485" alt="image" src="https://github.com/user-attachments/assets/ec4cd071-dd0a-4347-bf80-b69d354b7eee" />


---
Additionally, the README file was updated to reflect the actual YTUHD source used by the workflows.